### PR TITLE
[coverage|main].yml: silence actionlint warnings

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build MacPorts Base
         run: |
           set -eu
-          make -j$(sysctl -n hw.activecpu)
+          make -j"$(sysctl -n hw.activecpu)"
       - name: Install MacPorts Base
         run: |
           set -eu
@@ -40,15 +40,15 @@ jobs:
       - name: Test MacPorts Base
         run: |
           set -eu
-          LLVM_PROFILE_FILE="$PWD/cov-%p.profraw" make test
+          LLVM_PROFILE_FILE="${PWD}/cov-%p.profraw" make test
       - name: Report Coverage
         run: |
           set -eu
           xcrun llvm-profdata merge --sparse --output=cov.profdata cov-*.profraw
           # tracelib cannot be profiled
           OBJ_FILES="$(find src -type f "(" -name "*.dylib" -o -name "*.a" ")" | grep -Fv darwintracelib1.0 | sed 's/^/--arch=arm64 --object=/')"
-          xcrun llvm-cov show --format=html --output-dir=covreport --ignore-filename-regex=vendor/ --instr-profile=cov.profdata $OBJ_FILES
-          xcrun llvm-cov report --ignore-filename-regex=vendor/ --instr-profile=cov.profdata $OBJ_FILES
+          xcrun llvm-cov show --format=html --output-dir=covreport --ignore-filename-regex=vendor/ --instr-profile=cov.profdata "${OBJ_FILES}"
+          xcrun llvm-cov report --ignore-filename-regex=vendor/ --instr-profile=cov.profdata "${OBJ_FILES}"
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Select Xcode version
         if: startsWith(matrix.os,'macos')
         run: |
-          case "`uname -r`" in
+          case "$(uname -r)" in
             22.*) sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
                 ;;
             23.*) sudo xcode-select --switch /Applications/Xcode_15.3.app/Contents/Developer
@@ -47,9 +47,9 @@ jobs:
           set -eu
           platform=$(uname -s)
           case ${platform} in
-            Darwin) make -j$(sysctl -n hw.activecpu)
+            Darwin) make -j"$(sysctl -n hw.activecpu)"
             ;;
-            Linux) make -j$(nproc)
+            Linux) make -j"$(nproc)"
             ;;
           esac
       - name: Install MacPorts Base


### PR DESCRIPTION
mostly from shellcheck about variable quoting